### PR TITLE
Update falcon_data_replicator.ini and ocsf.py for configuration

### DIFF
--- a/falcon_data_replicator.ini
+++ b/falcon_data_replicator.ini
@@ -71,7 +71,7 @@ TARGET_REGION = %(AWS_TARGET_REGION)s
 REMOVE_LOCAL_FILE = yes
 # No local file system usage
 # Allowed values: True, False, Yes, No
-IN_MEMORY_TRANSFER_ONLY = yes
+IN_MEMORY_TRANSFER_ONLY = No
 # Convert inbound data into OCSF format before
 # publishing it to the target bucket or folder
 DO_OCSF_CONVERSION = yes

--- a/ocsf/ocsf.py
+++ b/ocsf/ocsf.py
@@ -47,8 +47,8 @@ def upload_parquet_files_to_s3(fdr, s3_target, log_utl: Logger):
                         lock = FileLock(upload_file_path + ".lock")
                         with lock:
                             with open(upload_file_path, 'rb') as parquet_data:
-                                log_utl.debug('@@@@uploaded_file@@@@=%s', upload_file_path)
-                                s3_target.upload_fileobj(parquet_data, fdr.target_bucket_name, upload_file_path)
+                                log_utl.info('@@@@uploaded_file@@@@=%s', upload_file_path)
+                                # s3_target.upload_fileobj(parquet_data, fdr.target_bucket_name, upload_file_path)
                             # Remove the file from the local file system
                             os.remove(upload_file_path)
 


### PR DESCRIPTION
This pull request makes small but important configuration and logging adjustments to the Falcon Data Replicator and the OCSF upload process. The main changes involve updating transfer settings in the configuration file and modifying logging behavior in the file upload function.

Configuration update:

* Changed the value of `IN_MEMORY_TRANSFER_ONLY` from `yes` to `No` in `falcon_data_replicator.ini`, altering how file transfers are handled.

Logging and upload behavior:

* Upgraded the logging level from `debug` to `info` for file uploads in the `upload_parquet_files_to_s3` function in `ocsf.py`.
* Commented out the actual S3 upload operation in the same function, potentially for testing or debugging purposes.