### PR TITLE
Update logging and configuration in falcon_data_replicator and ocsf modules

### DIFF
--- a/falcon_data_replicator.ini
+++ b/falcon_data_replicator.ini
@@ -71,7 +71,7 @@ TARGET_REGION = %(AWS_TARGET_REGION)s
 REMOVE_LOCAL_FILE = yes
 # No local file system usage
 # Allowed values: True, False, Yes, No
-IN_MEMORY_TRANSFER_ONLY = No
+IN_MEMORY_TRANSFER_ONLY = yes
 # Convert inbound data into OCSF format before
 # publishing it to the target bucket or folder
 DO_OCSF_CONVERSION = yes

--- a/falcon_data_replicator.py
+++ b/falcon_data_replicator.py
@@ -156,7 +156,6 @@ def download_message_files(msg, s3ta, s3or, log: logging.Logger):
     for s3_file in msg["files"]:
         # Retrieve the bucket path for this file
         s3_path = s3_file["path"]
-        log.info("s3_path: %s", s3_path)
         total_download_time_per_input_file = 0
         if not FDR.in_memory_transfer_only:
             log.info("Downloading file to local file system")
@@ -184,7 +183,7 @@ def download_message_files(msg, s3ta, s3or, log: logging.Logger):
             with open(local_path, "wb") as data:
                 # Download the file from S3 into our opened local file
                 s3or.download_fileobj(msg["bucket"], s3_path, data)
-            log.debug("Downloaded file to path %s", local_path)
+            log.info("Downloaded file to path %s", local_path)
             total_download_time_per_input_file = time.time() - start_download_time
             # Handle S3 upload if configured
             result = handle_file(local_path, s3_path, s3ta, None, log)
@@ -234,7 +233,6 @@ def process_queue_message(msg, s3b, s3o, log_util: logging.Logger):
     log_util.info("Processing message [%s]", msg.message_id)
     # Grab the actual message body
     body = json.loads(msg.body)
-    log_util.info("Body: %s", body)
     # Download the file to our local file system and potentially upload it to S3
     metrics = download_message_files(body, s3b, s3o, log_util)
     log_util.info("Removing message [%s] from queue", msg.message_id)

--- a/ocsf/ocsf.py
+++ b/ocsf/ocsf.py
@@ -35,7 +35,7 @@ def upload_parquet_files_to_s3(fdr, s3_target, log_utl: Logger):
                 for filename in filenames:
                     upload_file_path = os.path.join(root, filename)
                     timestamp_str = filename.split('_')[-1].split('.')[0]
-
+                    log_utl.info("upload_file_path: %s", upload_file_path)
                     if not filename.endswith('parquet'):
                         continue
 


### PR DESCRIPTION
This pull request focuses on improving logging consistency and configuration for in-memory data transfers in the Falcon Data Replicator. The main changes include updating configuration values to ensure in-memory transfers are enabled, adjusting logging levels for better visibility, and refining log output to reduce unnecessary verbosity.

Configuration updates:

* Changed the value of `IN_MEMORY_TRANSFER_ONLY` in `falcon_data_replicator.ini` from `No` to `yes`, ensuring that only in-memory transfers are performed.

Logging improvements:

* Upgraded the log level from `debug` to `info` for messages indicating a file has been downloaded to a local path in `falcon_data_replicator.py`, making these events more visible in production logs.
* Added an `info` log statement to display the path of each file being uploaded in `upload_parquet_files_to_s3` within `ocsf/ocsf.py`.

Log output refinement:

* Removed verbose log statements that output the full S3 path and message body, reducing unnecessary log clutter in `falcon_data_replicator.py`. [[1]](diffhunk://#diff-5fe25aecd25d83ed012faff7879447df520bdd55395270356dda82e446941393L159) [[2]](diffhunk://#diff-5fe25aecd25d83ed012faff7879447df520bdd55395270356dda82e446941393L237)