### PR TITLE
Enhance logging in falcon_data_replicator.py to include target bucket…

### DIFF
--- a/standalone/falcon_data_replicator.py
+++ b/standalone/falcon_data_replicator.py
@@ -133,6 +133,7 @@ def clean_exit(stat, signal, frame):  # pylint: disable=W0613
 def handle_file(path, key, file_object=None):
     """If configured, upload this file to our target bucket and remove it."""
     # If we've defined a target bucket
+    logger.info("FDR.target_bucket_name: %s", FDR.target_bucket_name)
     if FDR.target_bucket_name:
         if not file_object:
             # Open our local file (binary)


### PR DESCRIPTION
This pull request adds a minor logging improvement to `standalone/falcon_data_replicator.py` to help with debugging and monitoring. The most notable change is the addition of a log statement that outputs the value of the target bucket name when handling files.

Logging and observability:

* Added an info-level log statement to display the value of `FDR.target_bucket_name` at the start of the `handle_file` function in `standalone/falcon_data_replicator.py`.… name information for improved traceability during file handling.