### PR TITLE
Update falcon_data_replicator.ini and enhance logging in falcon_data_replicator.py and ocsf.py for improved traceability

### DIFF
--- a/falcon_data_replicator.ini
+++ b/falcon_data_replicator.ini
@@ -71,7 +71,7 @@ TARGET_REGION = %(AWS_TARGET_REGION)s
 REMOVE_LOCAL_FILE = yes
 # No local file system usage
 # Allowed values: True, False, Yes, No
-IN_MEMORY_TRANSFER_ONLY = yes
+IN_MEMORY_TRANSFER_ONLY = no
 # Convert inbound data into OCSF format before
 # publishing it to the target bucket or folder
 DO_OCSF_CONVERSION = yes

--- a/falcon_data_replicator.py
+++ b/falcon_data_replicator.py
@@ -105,6 +105,7 @@ def handle_file(path, key, target_bkt, file_object=None, log_util: logging.Logge
                 transform_time = time.time() - start_transform_time
                 # upload the file that meets the criteria
                 start_upload_time = time.time()
+                log_util.info("[no file_object, do_ocsf] Uploading file to path %s", key)
                 upload_parquet_files_to_s3(FDR, target_bkt, log_util)
                 upload_time = time.time() - start_upload_time
             else:
@@ -128,10 +129,12 @@ def handle_file(path, key, target_bkt, file_object=None, log_util: logging.Logge
                 transform_time = time.time() - start_transform_time
                 # upload the file that meets the criteria
                 start_upload_time = time.time()
+                log_util.info("[file_object, do_ocsf] Uploading file to path %s", key)
                 upload_parquet_files_to_s3(FDR, target_bkt, log_util)
                 upload_time = time.time() - start_upload_time
             else:
                 start_upload_time = time.time()
+                log_util.info("[file_object, not do_ocsf] Uploading file to path %s", key)
                 target_bkt.upload_fileobj(file_object, FDR.target_bucket_name, key)
                 log_util.info("Uploaded file to path %s", key)
                 upload_time = time.time() - start_upload_time

--- a/ocsf/ocsf.py
+++ b/ocsf/ocsf.py
@@ -87,13 +87,13 @@ def write_to_parquet_file(fdr, ocsf_events, filename_class_uid_key, log_utl: Log
                     lock = FileLock(parquet_file_name + ".lock")
                     with lock:
                         events_wrote_to_file = True
-                        log_utl.debug('!!!!!!!!!!Update to bucket=%s, record_len=%s, file_name=%s',
+                        log_utl.info('!!!!!!!!!!Update to bucket=%s, record_len=%s, file_name=%s',
                                       filename_class_uid_key,
                                       len(ocsf_events), parquet_file_name)
                         existing_data = pd.read_parquet(parquet_file_name)
                         existing_data.sort_index(axis=1, inplace=True)
                         concat_data = pd.concat([existing_data, data], axis=0)
-                        concat_data.to_parquet(parquet_file_name, compression='gzip', index=False)
+                        concat_data.to_parquet(parquet_file_name, index=False)
         if not events_wrote_to_file:
             parquet_file_name = filename_class_uid_key + '_chunk_' + str(
                 int(datetime.utcnow().timestamp())) + '.parquet'
@@ -101,7 +101,7 @@ def write_to_parquet_file(fdr, ocsf_events, filename_class_uid_key, log_utl: Log
             with lock:
                 log_utl.debug('#########Write to bucket=%s, record_len=%s, file_name=%s', filename_class_uid_key,
                               len(ocsf_events), parquet_file_name)
-                data.to_parquet(parquet_file_name, compression='gzip', index=False)
+                data.to_parquet(parquet_file_name, index=False)
 
 
 def read_fdr_part(rdr):


### PR DESCRIPTION
This pull request introduces several changes to improve logging clarity, adjust file transfer behavior, and modify how Parquet files are written in the Falcon Data Replicator. The most impactful updates involve toggling in-memory transfer settings, enhancing upload operation logs, and altering Parquet file compression.

**Configuration and Data Transfer:**

* Disabled in-memory-only transfers by setting `IN_MEMORY_TRANSFER_ONLY = no` in `falcon_data_replicator.ini`, allowing local file system usage for transfers.

**Logging Enhancements:**

* Added detailed logging in `handle_file` in `falcon_data_replicator.py` to indicate the upload operation context (whether using a file object and/or OCSF conversion). [[1]](diffhunk://#diff-5fe25aecd25d83ed012faff7879447df520bdd55395270356dda82e446941393R108) [[2]](diffhunk://#diff-5fe25aecd25d83ed012faff7879447df520bdd55395270356dda82e446941393R132-R137)

**Parquet File Handling:**

* Changed log level from `debug` to `info` for updates to Parquet files in `write_to_parquet_file` in `ocsf/ocsf.py` for better visibility.
* Removed `gzip` compression from Parquet file writes, now saving files without compression for both update and chunk write operations.